### PR TITLE
Update GPG maven settings for GPG v 2.1+, and add Build instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,20 @@ binding you want (depends on the vendor)
 
 If you miss an endpoint feel free to make a pull request. Any help is appreciated.
 
+### Building
+
+If you've forked the repository and want to run the install goal to use your fork in your own project, please be aware
+the artifacts generated require being signed via GPG. 
+
+Once you've installed GPG and created a key-pair, you'll be prompted for your passphrase everytime you run the build. 
+You can automate this by supplying `gpg.passphrase` property during the build, for example:
+
+```
+mvn verify -Dgpg.passphrase=YOURPASSPHRASE
+```
+   
+In IntelliJ, you can supply the property via `File > Settings > Build, Execution, Deployment > Maven > Runner > Properties`.
+Once the `gpg.passphrase` property has been set there, you won't be prompted everytime you run the build.
+
 ---
 **Thanks to Palakis for the great plugin!**

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,10 @@
                 <version>1.5</version>
                 <configuration>
                     <skip>false</skip>
+                    <gpgArguments>
+                        <arg>--pinentry-mode</arg>
+                        <arg>loopback</arg>
+                    </gpgArguments>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -4,4 +4,4 @@ org.eclipse.jetty.LEVEL=OFF
 
 # Default levels for the project
 org.slf4j.simpleLogger.defaultLogLevel=info
-org.slf4j.simpleLogger.log.net.twasi.obsremotejava=debuggi
+org.slf4j.simpleLogger.log.net.twasi.obsremotejava=debug


### PR DESCRIPTION
See / Fixes #20 

Requesting to merge in changes on my fork that fix #20 ; e.g. adding the config to the GPG plugin settings, and adding a section on the README explaining the build process.