### PR TITLE
Feature: New Event Callbacks: SwitchTransition, TransitionListChanged

### DIFF
--- a/src/main/java/net/twasi/obsremotejava/OBSCommunicator.java
+++ b/src/main/java/net/twasi/obsremotejava/OBSCommunicator.java
@@ -8,10 +8,7 @@ import net.twasi.obsremotejava.callbacks.Callback;
 import net.twasi.obsremotejava.callbacks.ErrorCallback;
 import net.twasi.obsremotejava.callbacks.StringCallback;
 import net.twasi.obsremotejava.events.EventType;
-import net.twasi.obsremotejava.events.responses.ScenesChangedResponse;
-import net.twasi.obsremotejava.events.responses.SwitchScenesResponse;
-import net.twasi.obsremotejava.events.responses.TransitionBeginResponse;
-import net.twasi.obsremotejava.events.responses.TransitionEndResponse;
+import net.twasi.obsremotejava.events.responses.*;
 import net.twasi.obsremotejava.objects.throwables.InvalidResponseTypeError;
 import net.twasi.obsremotejava.requests.Authenticate.AuthenticateRequest;
 import net.twasi.obsremotejava.requests.Authenticate.AuthenticateResponse;
@@ -123,6 +120,8 @@ public class OBSCommunicator {
     private Callback onStreamStopped;
     private Callback onSwitchScenes;
     private Callback onScenesChanged;
+    private Callback onSwitchTransition;
+    private Callback onTransitionListChanged;
     private Callback onTransitionBegin;
     private Callback onTransitionEnd;
 
@@ -292,6 +291,16 @@ public class OBSCommunicator {
                     onScenesChanged.run(new Gson().fromJson(msg, ScenesChangedResponse.class));
                 }
                 break;
+            case SwitchTransition:
+                if (onSwitchTransition != null) {
+                    onSwitchTransition.run(new Gson().fromJson(msg, SwitchTransitionResponse.class));
+                }
+                break;
+            case TransitionListChanged:
+                if (onTransitionListChanged != null) {
+                    onTransitionListChanged.run(new Gson().fromJson(msg, TransitionListChangedResponse.class));
+                }
+                break;
             case TransitionBegin:
                 if (onTransitionBegin != null) {
                     onTransitionBegin.run(new Gson().fromJson(msg, TransitionBeginResponse.class));
@@ -395,6 +404,14 @@ public class OBSCommunicator {
 
     public void registerOnScenesChanged(Callback onScenesChanged) {
         this.onScenesChanged = onScenesChanged;
+    }
+
+    public void registerOnSwitchTransition(Callback onSwitchTransition) {
+        this.onSwitchTransition = onSwitchTransition;
+    }
+
+    public void registerOnTransitionListChanged(Callback onTransitionListChanged) {
+        this.onTransitionListChanged = onTransitionListChanged;
     }
 
     public void registerOnTransitionBegin(Callback onTransitionBegin) {

--- a/src/main/java/net/twasi/obsremotejava/OBSRemoteController.java
+++ b/src/main/java/net/twasi/obsremotejava/OBSRemoteController.java
@@ -170,6 +170,14 @@ public class OBSRemoteController {
         communicator.registerOnScenesChanged(onScenesChanged);
     }
 
+    public void registerSwitchTransitionCallback(Callback onSwitchTransition) {
+        communicator.registerOnSwitchTransition(onSwitchTransition);
+    }
+
+    public void registerTransitionListChangedCallback(Callback onTransitionListChanged) {
+        communicator.registerOnTransitionListChanged(onTransitionListChanged);
+    }
+
     public void registerTransitionBeginCallback(Callback onTransitionBegin) {
         communicator.registerOnTransitionBegin(onTransitionBegin);
     }

--- a/src/main/java/net/twasi/obsremotejava/events/EventType.java
+++ b/src/main/java/net/twasi/obsremotejava/events/EventType.java
@@ -11,6 +11,8 @@ public enum EventType {
     StreamStopped,
     SwitchScenes,
     ScenesChanged,
+    SwitchTransition,
+    TransitionListChanged,
     TransitionBegin,
     TransitionEnd
 }

--- a/src/main/java/net/twasi/obsremotejava/events/responses/SwitchTransitionResponse.java
+++ b/src/main/java/net/twasi/obsremotejava/events/responses/SwitchTransitionResponse.java
@@ -1,0 +1,13 @@
+package net.twasi.obsremotejava.events.responses;
+
+import com.google.gson.annotations.SerializedName;
+import net.twasi.obsremotejava.requests.ResponseBase;
+
+public class SwitchTransitionResponse extends ResponseBase {
+    @SerializedName("transition-name")
+    private String transitionName;
+
+    public String getTransitionName() {
+        return transitionName;
+    }
+}

--- a/src/main/java/net/twasi/obsremotejava/events/responses/TransitionListChangedResponse.java
+++ b/src/main/java/net/twasi/obsremotejava/events/responses/TransitionListChangedResponse.java
@@ -1,0 +1,17 @@
+package net.twasi.obsremotejava.events.responses;
+
+import net.twasi.obsremotejava.requests.ResponseBase;
+
+public class TransitionListChangedResponse extends ResponseBase {
+    // Leaving this empty for now to match ScenesChangedResponse event strategy.
+    //
+    // We may want to populate both of these with scenes/transitions when changed:
+    // The list of available transitions has been modified. Transitions have been added, removed, or renamed.
+    //
+    // Response Items:
+    //
+    // Name                 Type            Description
+    // ---                  ---             ---
+    // transitions          Array<Object>   Transitions list.
+    // transitions.*.name   String          Transition name.
+}

--- a/src/main/java/net/twasi/obsremotejava/events/responses/TransitionListChangedResponse.java
+++ b/src/main/java/net/twasi/obsremotejava/events/responses/TransitionListChangedResponse.java
@@ -1,17 +1,13 @@
 package net.twasi.obsremotejava.events.responses;
 
+import net.twasi.obsremotejava.objects.Transition;
 import net.twasi.obsremotejava.requests.ResponseBase;
 
+import java.util.List;
+
 public class TransitionListChangedResponse extends ResponseBase {
-    // Leaving this empty for now to match ScenesChangedResponse event strategy.
-    //
-    // We may want to populate both of these with scenes/transitions when changed:
-    // The list of available transitions has been modified. Transitions have been added, removed, or renamed.
-    //
-    // Response Items:
-    //
-    // Name                 Type            Description
-    // ---                  ---             ---
-    // transitions          Array<Object>   Transitions list.
-    // transitions.*.name   String          Transition name.
+    // Note: enabled these when https://github.com/Palakis/obs-websocket/blob/4.x-current/src/WSEvents.cpp#L561 is released.
+    // private List<Transition> transitions;
+
+    // public List<Transition> getTransitions() { return transitions; }
 }

--- a/src/main/java/net/twasi/obsremotejava/objects/Transition.java
+++ b/src/main/java/net/twasi/obsremotejava/objects/Transition.java
@@ -1,0 +1,9 @@
+package net.twasi.obsremotejava.objects;
+
+public class Transition {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/net/twasi/obsremotejava/requests/GetTransitionList/GetTransitionListResponse.java
+++ b/src/main/java/net/twasi/obsremotejava/requests/GetTransitionList/GetTransitionListResponse.java
@@ -1,6 +1,7 @@
 package net.twasi.obsremotejava.requests.GetTransitionList;
 
 import com.google.gson.annotations.SerializedName;
+import net.twasi.obsremotejava.objects.Transition;
 import net.twasi.obsremotejava.requests.ResponseBase;
 
 import java.util.List;
@@ -17,13 +18,5 @@ public class GetTransitionListResponse extends ResponseBase {
 
     public List<Transition> getTransitions() {
         return transitions;
-    }
-
-    public class Transition {
-        private String name;
-
-        public String getName() {
-            return name;
-        }
     }
 }

--- a/src/test/java/net/twasi/obsremotejava/test/OBSRemoteControllerUnsecuredIT.java
+++ b/src/test/java/net/twasi/obsremotejava/test/OBSRemoteControllerUnsecuredIT.java
@@ -2,10 +2,7 @@ package net.twasi.obsremotejava.test;
 
 import net.twasi.obsremotejava.callbacks.Callback;
 import net.twasi.obsremotejava.OBSRemoteController;
-import net.twasi.obsremotejava.events.responses.ScenesChangedResponse;
-import net.twasi.obsremotejava.events.responses.SwitchScenesResponse;
-import net.twasi.obsremotejava.events.responses.TransitionBeginResponse;
-import net.twasi.obsremotejava.events.responses.TransitionEndResponse;
+import net.twasi.obsremotejava.events.responses.*;
 import net.twasi.obsremotejava.requests.GetVersion.GetVersionResponse;
 import net.twasi.obsremotejava.requests.ResponseBase;
 import org.junit.jupiter.api.Disabled;
@@ -263,6 +260,16 @@ public class OBSRemoteControllerUnsecuredIT {
                 controller.registerScenesChangedCallback(res -> {
                     ScenesChangedResponse scenesChangedResponse = (ScenesChangedResponse) res;
                     System.out.println("Scenes changed");
+                });
+
+                controller.registerSwitchTransitionCallback(res -> {
+                    SwitchTransitionResponse switchTransitionResponse = (SwitchTransitionResponse) res;
+                    System.out.println("Switched active transition to: " + switchTransitionResponse.getTransitionName());
+                });
+
+                controller.registerTransitionListChangedCallback(res -> {
+                    TransitionListChangedResponse transitionListChangedResponse = (TransitionListChangedResponse) res;
+                    System.out.println("Transition list changed");
                 });
 
                 controller.registerTransitionBeginCallback(res -> {

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -4,4 +4,4 @@ org.eclipse.jetty.LEVEL=OFF
 
 # Default levels for the project
 org.slf4j.simpleLogger.defaultLogLevel=info
-org.slf4j.simpleLogger.log.net.twasi.obsremotejava=debuggi
+org.slf4j.simpleLogger.log.net.twasi.obsremotejava=debug


### PR DESCRIPTION
Hey guys,

I am working on some upstream features for [OBS Scene Que](https://github.com/sampie777/obs-scene-que) related to scene transitions.  I am trying to be able to use transitions cleanly, but I noticed that as part of this repo, there were two callback events from the [OBS Websocket Protocol](https://github.com/Palakis/obs-websocket/blob/4.x-current/docs/generated/protocol.md) that are not currently implemented in this library.

Those two event callbacks are: SwitchTransition, TransitionListChanged.

Note, these are both `v4.0.0` events--I am not totally clear on all the versioning but AFAIK this seems to work.

*SwitchTransition* triggers when the active transition changes within OBS (via SetCurrentTransition, for example).  This returns a simple JSON object:
```json
{
    "transition-name": "Fade"
}
```

I wrote a handler to bubble this upstream so that we can update the current transition OBS is using.

*TransitionListChanged* triggers when the transition list in OBS changes.  This may be due to additional transitions added or removed.

This returns an array of the transitions names, but like ScenesChangedResponse (https://github.com/Twasi/websocket-obs-java/blob/develop/src/main/java/net/twasi/obsremotejava/events/responses/ScenesChangedResponse.java), I'm opting to keep this one simpler and just bubble up the event so that the upstream system can decide how to handle it.

```json
{
    "transitions": [
        {
            "name": "Fade"
        },
        {
            "name": "Luma Wipe"
        }
    ]
}
```

Finally--I extracted `Transaction` from the Response object to be a first class citizen so tests and other things can be directly written against it.

Thanks! Please take a look and let me know if there's anything else I should consider!